### PR TITLE
Add support for custom stream name.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,7 +40,7 @@ function request(message, fn){
   delete json.context;
   delete json.projectId;
   return this
-    .post(fmt('/%s/segmentio', this.settings.cid))
+    .post(fmt('/%s/segmentio?stream=%s', this.settings.cid, this.settings.stream||'default'))
     .query({ access_token: this.settings.apiKey })
     .type('json')
     .send(json)

--- a/test/index.js
+++ b/test/index.js
@@ -10,14 +10,23 @@ describe('Lytics', function(){
   var settings;
   var lytics;
   var test;
+  var defaultTest;
 
   beforeEach(function(){
     settings = {
       apiKey: 'LPv7adzJu8IhRMTbgWmaagxx',
-      cid: 1289
+      cid: 1289,
+      stream: 'test'
     };
     lytics = new Lytics(settings);
     test = Test(lytics, __dirname);
+
+    defaultSettings = {
+      apiKey: 'LPv7adzJu8IhRMTbgWmaagxx',
+      cid: 1289
+    };
+    defaultLytics = new Lytics(defaultSettings);
+    defaultTest = Test(defaultLytics, __dirname);
   });
 
   it('should have the correct settings', function(){
@@ -57,7 +66,7 @@ describe('Lytics', function(){
       test
         .set(settings)
         .track(track)
-        .query({ access_token: settings.apiKey })
+        .query({ stream: 'test', access_token: settings.apiKey })
         .sends(json)
         .requests(1)
         .expects(200)
@@ -77,7 +86,7 @@ describe('Lytics', function(){
       test
         .set(settings)
         .identify(identify)
-        .query({ access_token: settings.apiKey })
+        .query({ stream: 'test', access_token: settings.apiKey })
         .sends(json)
         .requests(1)
         .expects(200)
@@ -97,7 +106,68 @@ describe('Lytics', function(){
       test
         .set(settings)
         .alias(alias)
-        .query({ access_token: settings.apiKey })
+        .query({ stream: 'test', access_token: settings.apiKey })
+        .sends(json)
+        .requests(1)
+        .expects(200)
+        .end(done);
+    });
+  });
+
+  // test with default values
+  describe('.track()', function(){
+    it('should track successfully', function(done){
+      var track = helpers.track();
+      var json = track.json();
+
+      json.options = json.options || json.context;
+      delete json.context;
+      delete json.projectId;
+
+      defaultTest
+        .set(defaultSettings)
+        .track(track)
+        .query({ stream: 'default', access_token: settings.apiKey })
+        .sends(json)
+        .requests(1)
+        .expects(200)
+        .end(done);
+    });
+  });
+
+  describe('.identify()', function(){
+    it('should identify successfully', function(done){
+      var identify = helpers.identify();
+      var json = identify.json();
+
+      json.options = json.options || json.context;
+      delete json.context;
+      delete json.projectId;
+
+      defaultTest
+        .set(defaultSettings)
+        .identify(identify)
+        .query({ stream: 'default', access_token: settings.apiKey })
+        .sends(json)
+        .requests(1)
+        .expects(200)
+        .end(done);
+    });
+  });
+
+  describe('.alias()', function(){
+    it('should alias successfully', function(done){
+      var alias = helpers.alias();
+      var json = alias.json();
+
+      json.options = json.options || json.context;
+      delete json.context;
+      delete json.projectId;
+
+      defaultTest
+        .set(defaultSettings)
+        .alias(alias)
+        .query({ stream: 'default', access_token: settings.apiKey })
         .sends(json)
         .requests(1)
         .expects(200)


### PR DESCRIPTION
Customers can now define their stream name in the Segment UI. If there is no value it should just default to "default" which we handle on our end. Added tests to verify the default fallback works properly.
